### PR TITLE
Fix Resolve in bin.mts

### DIFF
--- a/src/bin.mts
+++ b/src/bin.mts
@@ -14,7 +14,9 @@ import supportsColor from 'supports-color';
 import { fileURLToPath, pathToFileURL } from 'url';
 import yargs from 'yargs';
 import { IDesktopTestConfiguration, TestConfiguration } from './config.cjs';
+import { createRequire } from 'node:module';
 
+const require = createRequire(import.meta.url);
 const rulesAndBehavior = 'Mocha: Rules & Behavior';
 const reportingAndOutput = 'Mocha: Reporting & Output';
 const fileHandling = 'Mocha: File Handling';


### PR DESCRIPTION
CC @connor4312 

bin.mts is an ES module, but tries to use `require.resolve` which is only available to CommonJS modules. This generates a requires so things work properly. The future option is to use `import.meta.requires` if it ever goes stable. This type of resolution is also generally not necessary, passing through the relative paths works fine as well.