### PR TITLE
✨ Feature: Install Dependent/Prerequisite Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ export default defineConfig([
 		extensionDevelopmentPath: __dirname,
 		// Optional: sample workspace to open
 		workspaceFolder: `${__dirname}/sampleWorkspace`,
+    // Optional: install additional extensions to the installation prior to testing
+    extensionsToInstall: 'ms-vscode.js-debug-nightly@prerelease'
+    // Optional: install extensions listed in extensionDependencies key of your project.json at extensionDevelopmentPath
+    installExtensionDependencies: true
 		// Optional: additional mocha options to use:
 		mocha: {
 			preload: `./out/test-utils.js`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@koa/cors": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-4.0.0.tgz",
-      "integrity": "sha512-Y4RrbvGTlAaa04DBoPBWJqDR5gPj32OOz827ULXfgB1F7piD1MB/zwn8JR2LAnvdILhxUbXbkXGWuNVsFuVFCQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@koa/cors/-/cors-5.0.0.tgz",
+      "integrity": "sha512-x/iUDjcS90W69PryLDIMgFyV21YLTnG9zOpPXS7Bkt2b8AsY3zZsIpOLBkYr9fBcF3HbkKaER5hOBZLfpLgYNw==",
       "dev": true,
       "dependencies": {
         "vary": "^1.1.2"
@@ -58,11 +58,12 @@
       }
     },
     "node_modules/@koa/router": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@koa/router/-/router-12.0.0.tgz",
-      "integrity": "sha512-cnnxeKHXlt7XARJptflGURdJaO+ITpNkOHmQu7NHmCoRinPbyvFzce/EG/E8Zy81yQ1W9MoSdtklc3nyaDReUw==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@koa/router/-/router-12.0.1.tgz",
+      "integrity": "sha512-ribfPYfHb+Uw3b27Eiw6NPqjhIhTpVFzEWLwyc/1Xp+DCdwRRyIlAUODX+9bPARF6aQtUu1+/PHzdNvRzcs/+Q==",
       "dev": true,
       "dependencies": {
+        "debug": "^4.3.4",
         "http-errors": "^2.0.0",
         "koa-compose": "^4.1.0",
         "methods": "^1.1.2",
@@ -82,13 +83,13 @@
       }
     },
     "node_modules/@playwright/browser-chromium": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.38.1.tgz",
-      "integrity": "sha512-HRhcBGtk1XaGAQjOben/04PNHxWAY3DBHT97egraR5lx5SQSLOREIiYu/j7WlvQBz4QJP+XL2JsvoxFBJfXmAw==",
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@playwright/browser-chromium/-/browser-chromium-1.41.1.tgz",
+      "integrity": "sha512-rgPTuAmA+8zQLb7+GDY7hrdnCRMrL2C/JPFylWeQBJkQtldJsk2pELUR7NESeJtXVzML/x+aFnGPRY0r5+YO3Q==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "playwright-core": "1.38.1"
+        "playwright-core": "1.41.1"
       },
       "engines": {
         "node": ">=16"
@@ -104,35 +105,38 @@
       }
     },
     "node_modules/@types/mocha": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.2.tgz",
-      "integrity": "sha512-NaHL0+0lLNhX6d9rs+NSt97WH/gIlRHmszXbQ/8/MV/eVcFNdeJ/GYhrFuUc8K7WuPhRhTSdMkCp8VMzhUq85w=="
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
+      "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg=="
     },
     "node_modules/@types/node": {
-      "version": "18.18.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.4.tgz",
-      "integrity": "sha512-t3rNFBgJRugIhackit2mVcLfF6IRc0JE4oeizPQL8Zrm8n2WY/0wOdpOPhdtG0V9Q2TlW/axbF1MJ6z+Yj/kKQ==",
-      "dev": true
+      "version": "18.19.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.14.tgz",
+      "integrity": "sha512-EnQ4Us2rmOS64nHDWr0XqAD8DsO6f3XR6lf9UIIrZQpUzPVdN/oPuEzfDWNHSyXLvoGgjuEm/sPwFGSSs35Wtg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.28",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-      "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
+      "version": "17.0.32",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
+      "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
       "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
     },
     "node_modules/@types/yargs-parser": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.1.tgz",
-      "integrity": "sha512-axdPBuLuEJt0c4yI5OZssC19K2Mq1uKdrfZBzuxLvaztgqUtFYZUNw7lETExPYJR9jdEoIg4mb7RQKRQzOkeGQ==",
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.5.tgz",
-      "integrity": "sha512-lAW7nQ0HuPqJnGJrtCzEKZCICtRizeP6qNanyCrjmdCOAAWjX3ixiG8RVPwqsYPQBWLPgYuE12qQlwXsOR/2fQ==",
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.9.tgz",
+      "integrity": "sha512-z3eiChaCQXMqBnk2aHHSEkobmC2VRalFQN0ApOAtydL172zXGxTwGrRtviT5HnUB+Q+G3vtEYFtuQkYqBzYgMA==",
       "dev": true,
       "dependencies": {
         "http-proxy-agent": "^4.0.1",
@@ -145,25 +149,25 @@
       }
     },
     "node_modules/@vscode/test-web": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@vscode/test-web/-/test-web-0.0.46.tgz",
-      "integrity": "sha512-s5rKDtCvIWN6kJpjXzBoWpLvftjH3m2r2MQNGUGsdY1+mOJ06lbbHeJn+g30+p0ec4Vh7PpBZGECflrRW+oH4Q==",
+      "version": "0.0.51",
+      "resolved": "https://registry.npmjs.org/@vscode/test-web/-/test-web-0.0.51.tgz",
+      "integrity": "sha512-BULmM/HkTuWYuDQLq17L0XYZkzOtsIIC38HN5eYaVBUXSOSwXpyihTalsQ6y9GNPuGWZUnc2XqXYvR6gdSHHOg==",
       "dev": true,
       "dependencies": {
-        "@koa/cors": "^4.0.0",
-        "@koa/router": "^12.0.0",
-        "@playwright/browser-chromium": "^1.38.1",
+        "@koa/cors": "^5.0.0",
+        "@koa/router": "^12.0.1",
+        "@playwright/browser-chromium": "^1.41.1",
         "gunzip-maybe": "^1.4.2",
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.2",
-        "koa": "^2.14.2",
+        "koa": "^2.15.0",
         "koa-morgan": "^1.0.1",
         "koa-mount": "^4.0.0",
         "koa-static": "^5.0.0",
         "minimist": "^1.2.8",
-        "playwright": "^1.38.1",
+        "playwright": "^1.41.1",
         "tar-fs": "^3.0.4",
-        "vscode-uri": "^3.0.7"
+        "vscode-uri": "^3.0.8"
       },
       "bin": {
         "vscode-test-web": "out/index.js"
@@ -255,11 +259,14 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -397,20 +404,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/chalk/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/chalk/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -467,20 +460,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/cliui/node_modules/emoji-regex": {
@@ -581,9 +560,9 @@
       }
     },
     "node_modules/cookies": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.8.0.tgz",
-      "integrity": "sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
       "dev": true,
       "dependencies": {
         "depd": "~2.0.0",
@@ -896,26 +875,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.1.tgz",
+      "integrity": "sha512-6J4rC9ROz0UkOpjn0BRtSSqlewDTDYJNQvy8N8RSrPCduUWId1o9BQPEVII/KKBqRk/ZIQff1YbRkUDCH2N5Sg==",
       "dev": true,
-      "dependencies": {
-        "has-symbols": "^1.0.2"
-      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -1206,16 +1170,16 @@
       }
     },
     "node_modules/koa": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/koa/-/koa-2.14.2.tgz",
-      "integrity": "sha512-VFI2bpJaodz6P7x2uyLiX6RLYpZmOJqNmoCst/Yyd7hQlszyPwG/I9CQJ63nOtKSxpt5M7NH67V6nJL2BwCl7g==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.15.0.tgz",
+      "integrity": "sha512-KEL/vU1knsoUvfP4MC4/GthpQrY/p6dzwaaGI6Rt4NQuFqkw3qrvsdYF5pz3wOfi7IGTvMPHC9aZIcUKYFNxsw==",
       "dev": true,
       "dependencies": {
         "accepts": "^1.3.5",
         "cache-content-type": "^1.0.0",
         "content-disposition": "~0.5.2",
         "content-type": "^1.0.4",
-        "cookies": "~0.8.0",
+        "cookies": "~0.9.0",
         "debug": "^4.3.2",
         "delegates": "^1.0.0",
         "depd": "^2.0.0",
@@ -1423,9 +1387,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -1551,20 +1515,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/mocha/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/mocha/node_modules/cliui": {
@@ -1704,14 +1654,6 @@
         "y18n": "^5.0.5",
         "yargs-parser": "^20.2.2"
       },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/mocha/node_modules/yargs-parser": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
       "engines": {
         "node": ">=10"
       }
@@ -1938,12 +1880,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.38.1.tgz",
-      "integrity": "sha512-oRMSJmZrOu1FP5iu3UrCx8JEFRIMxLDM0c/3o4bpzU5Tz97BypefWf7TuTNPWeCe279TPal5RtPPZ+9lW/Qkow==",
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.41.1.tgz",
+      "integrity": "sha512-gdZAWG97oUnbBdRL3GuBvX3nDDmUOuqzV/D24dytqlKt+eI5KbwusluZRGljx1YoJKZ2NRPaeWiFTeGZO7SosQ==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.38.1"
+        "playwright-core": "1.41.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1956,9 +1898,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.38.1.tgz",
-      "integrity": "sha512-tQqNFUKa3OfMf4b2jQ7aGLB8o9bS3bOY0yMEtldtC2+spf8QXG9zvXLTXUeRsoNuxEYMgLYR+NXfAa1rjKRcrg==",
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.41.1.tgz",
+      "integrity": "sha512-/KPO5DzXSMlxSX77wy+HihKGOunh3hqndhqeo/nMxfigiKzogn8kfL0ZBDu0L1RKgan5XHCPmn6zXd2NUJgjhg==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"
@@ -1982,9 +1924,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
-      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
+      "integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -2241,15 +2183,15 @@
       }
     },
     "node_modules/stream-shift": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
       "dev": true
     },
     "node_modules/streamx": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.1.tgz",
-      "integrity": "sha512-fQMzy2O/Q47rgwErk/eGeLu/roaFWV0jVsogDmrszM9uIw8L5OA+t+V93MgYlufNptfjmYR1tOMWhei/Eh7TQA==",
+      "version": "2.15.6",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.6.tgz",
+      "integrity": "sha512-q+vQL4AAz+FdfT137VF69Cc/APqUbxy+MDOImRrMvchJpigHj9GksgDU2LYbO9rx7RX6osWgxJB2WxhYv4SZAw==",
       "dev": true,
       "dependencies": {
         "fast-fifo": "^1.1.0",
@@ -2403,9 +2345,9 @@
       }
     },
     "node_modules/tar-stream": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
-      "integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
       "dev": true,
       "dependencies": {
         "b4a": "^1.6.4",
@@ -2466,9 +2408,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2477,6 +2419,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -2559,20 +2507,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -2600,6 +2534,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/wrappy": {
@@ -2648,11 +2593,11 @@
       }
     },
     "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       }
     },
     "node_modules/yargs-unparser": {
@@ -2704,6 +2649,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ylru": {

--- a/src/bin.mts
+++ b/src/bin.mts
@@ -47,17 +47,16 @@ const args = yargs(process.argv)
     group: vscodeSection,
   })
   .option('install-extensions', {
-    alias: 'e',
     type: 'array',
     description:
       "A list of vscode extensions to install prior to running the tests. Can be specified as 'owner.extension','owner.extension@2.3.15', 'owner.extension@prerelease', or the path to a vsix file (/path/to/extension.vsix)",
     group: vscodeSection,
   })
-  .option('install-extension-dependencies', {
-    alias: 'd',
-    type: 'array',
+  .option('skip-extension-dependencies', {
+    type: 'boolean',
+    default: false,
     description:
-      'If specified, will install all extensions listed in the extensionDependencies key of the package.json located at ExtensionDevelopmentPath. Extension specifications (such as specifying a prerelease or pinned version) defined in extensions will override entries found via this setting.',
+      'By default, vscode-cli will install all extensions listed in the extensionDependencies key of the package.json located at ExtensionDevelopmentPath. --install-extensions will override any extensions found in this manner. This setting disables this autodiscovery behavior.',
     group: vscodeSection,
   })
   //#region Rules & Behavior
@@ -396,14 +395,14 @@ async function runConfigs(configs: readonly IConfigWithPath[]) {
       const desktopPlatform = config.desktopPlatform;
       const extensionDevelopmentPath = config.extensionDevelopmentPath?.slice() || dirname(path);
       const extensionsToInstall = args.installExtensions?.map(String) || config.installExtensions;
-      const installDependentExtensions =
-        !!args.installExtensionDependencies || config.installExtensionDependencies;
+      const skipExtensionDependencies =
+        !!args.skipExtensionDependencies || config.skipExtensionDependencies;
 
-      if (extensionsToInstall || installDependentExtensions) {
+      if (extensionsToInstall || skipExtensionDependencies) {
         const installResult = await installExtensions(
           extensionDevelopmentPath,
           extensionsToInstall,
-          installDependentExtensions,
+          skipExtensionDependencies,
           codeVersion,
           desktopPlatform,
           reporter,

--- a/src/bin.mts
+++ b/src/bin.mts
@@ -395,12 +395,15 @@ async function runConfigs(configs: readonly IConfigWithPath[]) {
       const reporter = config.download?.reporter;
       const desktopPlatform = config.desktopPlatform;
       const extensionDevelopmentPath = config.extensionDevelopmentPath?.slice() || dirname(path);
+      const extensionsToInstall = args.installExtensions?.map(String) || config.installExtensions;
+      const installDependentExtensions =
+        !!args.installExtensionDependencies || config.installExtensionDependencies;
 
-      if (config.installExtensions || config.installExtensionDependencies) {
+      if (extensionsToInstall || installDependentExtensions) {
         const installResult = await installExtensions(
           extensionDevelopmentPath,
-          args.installExtensions?.map(String) || config.installExtensions,
-          !!args.installExtensionDependencies || config.installExtensionDependencies,
+          extensionsToInstall,
+          installDependentExtensions,
           codeVersion,
           desktopPlatform,
           reporter,

--- a/src/config.cts
+++ b/src/config.cts
@@ -53,84 +53,90 @@ export interface IBaseTestConfiguration {
 }
 
 export interface IDesktopTestConfiguration extends IBaseTestConfiguration {
-	/**
-	 * Platform to use for running the tests.
-	 */
-	platform?: 'desktop';
+  /**
+   * Platform to use for running the tests.
+   */
+  platform?: 'desktop';
 
-	/**
-	 * The VS Code desktop platform to download. If not specified, it defaults
-	 * to the current platform.
-	 *
-	 * Possible values are:
-	 * 	- `win32-archive`
-	 * 	- `win32-x64-archive`
-	 * 	- `win32-arm64-archive		`
-	 * 	- `darwin`
-	 * 	- `darwin-arm64`
-	 * 	- `linux-x64`
-	 * 	- `linux-arm64`
-	 * 	- `linux-armhf`
-	 */
-	desktopPlatform?: string;
+  /**
+   * The VS Code desktop platform to download. If not specified, it defaults
+   * to the current platform.
+   *
+   * Possible values are:
+   * 	- `win32-archive`
+   * 	- `win32-x64-archive`
+   * 	- `win32-arm64-archive		`
+   * 	- `darwin`
+   * 	- `darwin-arm64`
+   * 	- `linux-x64`
+   * 	- `linux-arm64`
+   * 	- `linux-armhf`
+   */
+  desktopPlatform?: string;
 
-	/**
-	 * A list of launch arguments passed to VS Code executable, in addition to `--extensionDevelopmentPath`
-	 * and `--extensionTestsPath` which are provided by `extensionDevelopmentPath` and `extensionTestsPath`
-	 * options.
-	 *
-	 * If the first argument is a path to a file/folder/workspace, the launched VS Code instance
-	 * will open it.
-	 *
-	 * See `code --help` for possible arguments.
-	 */
-	launchArgs?: string[];
+  /**
+   * A list of launch arguments passed to VS Code executable, in addition to `--extensionDevelopmentPath`
+   * and `--extensionTestsPath` which are provided by `extensionDevelopmentPath` and `extensionTestsPath`
+   * options.
+   *
+   * If the first argument is a path to a file/folder/workspace, the launched VS Code instance
+   * will open it.
+   *
+   * See `code --help` for possible arguments.
+   */
+  launchArgs?: string[];
 
-	/**
-	 * Environment variables to set when running the test.
-	 */
-	env?: Record<string, string | undefined>;
+  /**
+   * Environment variables to set when running the test.
+   */
+  env?: Record<string, string | undefined>;
 
-	/**
-	 * Configures a specific VS Code installation to use instead of automatically
-	 * downloading the {@link version}
-	 */
-	useInstallation?:
-		| {
-				/**
-				 * Whether VS Code should be launched using default settings and extensions
-				 * installed on this machine. If `false`, then separate directories will be
-				 * used inside the `.vscode-test` folder within the project.
-				 *
-				 * Defaults to `false`.
-				 */
-				fromMachine: boolean;
-		  }
-		| {
-				/**
-				 * The VS Code executable path used for testing.
-				 *
-				 * If not passed, will use `options.version` to download a copy of VS Code for testing.
-				 * If `version` is not specified either, will download and use latest stable release.
-				 */
-				fromPath?: string;
-		  };
+  /**
+   * Configures a specific VS Code installation to use instead of automatically
+   * downloading the {@link version}
+   */
+  useInstallation?:
+    | {
+        /**
+         * Whether VS Code should be launched using default settings and extensions
+         * installed on this machine. If `false`, then separate directories will be
+         * used inside the `.vscode-test` folder within the project.
+         *
+         * Defaults to `false`.
+         */
+        fromMachine: boolean;
+      }
+    | {
+        /**
+         * The VS Code executable path used for testing.
+         *
+         * If not passed, will use `options.version` to download a copy of VS Code for testing.
+         * If `version` is not specified either, will download and use latest stable release.
+         */
+        fromPath?: string;
+      };
 
-	download?: {
-		/**
-		 * Progress reporter to use while VS Code is downloaded. Defaults to a
-		 * console reporter. A {@link SilentReporter} is also available, and you
-		 * may implement your own.
-		 */
+  download?: {
+    /**
+     * Progress reporter to use while VS Code is downloaded. Defaults to a
+     * console reporter. A {@link SilentReporter} is also available, and you
+     * may implement your own.
+     */
 
-		reporter: ProgressReporter;
-		/**
-		 * Number of milliseconds after which to time out if no data is received from
-		 * the remote when downloading VS Code. Note that this is an 'idle' timeout
-		 * and does not enforce the total time VS Code may take to download.
-		 */
-		timeout?: number;
-	};
+    reporter: ProgressReporter;
+    /**
+     * Number of milliseconds after which to time out if no data is received from
+     * the remote when downloading VS Code. Note that this is an 'idle' timeout
+     * and does not enforce the total time VS Code may take to download.
+     */
+    timeout?: number;
+  };
+
+  /** A list of vscode extensions to install prior to running the tests. Can be specified as 'owner.extension','owner.extension\@2.3.15', 'owner.extension\@prerelease', or the path to a vsix file (/path/to/extension.vsix) */
+  installExtensions?: string[];
+
+  /** If specified, will install all extensions listed in the extensionDependencies key of the package.json located at ExtensionDevelopmentPath. Extension specifications (such as specifying a prerelease or pinned version) defined in extensions will override entries found via this setting. */
+  installExtensionDependencies?: boolean;
 }
 
 /**

--- a/src/config.cts
+++ b/src/config.cts
@@ -135,8 +135,8 @@ export interface IDesktopTestConfiguration extends IBaseTestConfiguration {
   /** A list of vscode extensions to install prior to running the tests. Can be specified as 'owner.extension','owner.extension\@2.3.15', 'owner.extension\@prerelease', or the path to a vsix file (/path/to/extension.vsix) */
   installExtensions?: string[];
 
-  /** If specified, will install all extensions listed in the extensionDependencies key of the package.json located at ExtensionDevelopmentPath. Extension specifications (such as specifying a prerelease or pinned version) defined in extensions will override entries found via this setting. */
-  installExtensionDependencies?: boolean;
+  /** Skips the automatic extensionDependencies package.json discovery */
+  skipExtensionDependencies?: boolean;
 }
 
 /**

--- a/src/extensionInstall.mts
+++ b/src/extensionInstall.mts
@@ -1,0 +1,59 @@
+import electron, { ProgressReporter } from '@vscode/test-electron';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+
+export async function installExtensions(
+  extensionDevelopmentPath: string | string[],
+  extensions: string[] = [],
+  installDependentExtensions: boolean = false,
+  codeVersion?: string,
+  desktopPlatform?: string,
+  reporter?: ProgressReporter,
+) {
+  const vscodePath = await electron.downloadAndUnzipVSCode(codeVersion, desktopPlatform, reporter);
+
+  const extensionDevelopmentPaths = Array.isArray(extensionDevelopmentPath)
+    ? extensionDevelopmentPath
+    : [extensionDevelopmentPath];
+
+  const extensionsToInstall = installDependentExtensions
+    ? extensionDevelopmentPaths.flatMap((p) => mergeDependentExtensions(extensions, p))
+    : extensions;
+
+  const [cli, ...cliArgs] = electron.resolveCliArgsFromVSCodeExecutablePath(vscodePath);
+
+  for (const extension of extensionsToInstall) {
+    cliArgs.push('--install-extension', extension);
+  }
+
+  const installResult = spawnSync(cli, cliArgs, {
+    encoding: 'utf8',
+    stdio: 'inherit',
+  });
+  if (installResult.status !== 0) {
+    console.error(installResult.stderr);
+    throw new Error(`Failed to install extension: ${installResult.stderr}`);
+  }
+  // TODO: Stream via reporter
+  return installResult.stdout;
+}
+
+// Merge in the dependent extensions from the package.json file only if the base name prior to the @ symbol is not already specified in extensions
+function mergeDependentExtensions(extensions: string[], extensionDevelopmentPath: string) {
+  const packageJsonPath = path.join(extensionDevelopmentPath, 'package.json');
+  const dependencies: string[] = require(packageJsonPath).extensionDependencies;
+
+  if (!Array.isArray(dependencies)) {
+    throw new Error('extensionDependencies in package.json must be an array of strings');
+  }
+
+  const extensionsToInstall = new Set(extensions);
+  const extensionNames = extensions.map((extension) => extension.split('@')[0]);
+  for (const dependency of dependencies) {
+    const dependencyName = dependency.split('@')[0];
+    if (!extensionNames.includes(dependencyName)) {
+      extensionsToInstall.add(dependency);
+    }
+  }
+  return Array.from(extensionsToInstall);
+}

--- a/src/extensionInstall.mts
+++ b/src/extensionInstall.mts
@@ -45,7 +45,7 @@ export async function installExtensions(
 
 // Merge in the dependent extensions from the package.json file only if the base name prior to the @ symbol is not already specified in extensions
 function mergeDependentExtensions(extensions: string[], extensionDevelopmentPaths: string[]) {
-  const extensionsToInstall = new Set(extensions);
+  const extensionsToInstall = extensions.flat();
   // TODO: Edge case: we have same extension dependency in multiple development paths, choose lowest version?
   for (const extensionDevelopmentPath of extensionDevelopmentPaths) {
     const packageJsonPath = path.join(extensionDevelopmentPath, 'package.json');
@@ -61,17 +61,18 @@ function mergeDependentExtensions(extensions: string[], extensionDevelopmentPath
       );
     }
 
+    /** Effectively strips the version specification from the extension name */
+    const getExtensionName = (name: string) => name.split('@')[0];
+
     for (const dependency of dependencies) {
-      const extensionNames = Array.from(extensionsToInstall).map(
-        (extension) => extension.split('@')[0],
-      );
-      const dependencyName = dependency.split('@')[0];
+      const extensionNames = extensionsToInstall.map(getExtensionName);
+      const dependencyName = getExtensionName(dependency);
       if (!extensionNames.includes(dependencyName)) {
         console.debug(`Adding dependent extension ${dependency} from ${extensionDevelopmentPath}`);
-        extensionsToInstall.add(dependency);
+        extensionsToInstall.push(dependency);
       }
     }
   }
 
-  return Array.from(extensionsToInstall);
+  return extensionsToInstall;
 }

--- a/src/extensionInstall.mts
+++ b/src/extensionInstall.mts
@@ -24,6 +24,11 @@ export async function installExtensions(
     platform: desktopPlatform,
   });
 
+  if (extensionsToInstall.length === 0) {
+    console.debug('No extensions to install');
+    return;
+  }
+
   for (const extension of extensionsToInstall) {
     cliArgs.push('--install-extension', extension);
   }

--- a/src/extensionInstall.mts
+++ b/src/extensionInstall.mts
@@ -5,7 +5,7 @@ import path from 'node:path';
 export async function installExtensions(
   extensionDevelopmentPath: string | string[],
   extensions: string[] = [],
-  installDependentExtensions: boolean = false,
+  skipExtensionDependencies: boolean = false,
   codeVersion?: string,
   desktopPlatform?: string,
   reporter?: ProgressReporter,
@@ -16,9 +16,9 @@ export async function installExtensions(
     ? extensionDevelopmentPath
     : [extensionDevelopmentPath];
 
-  const extensionsToInstall = installDependentExtensions
-    ? mergeDependentExtensions(extensions, extensionDevelopmentPaths)
-    : extensions;
+  const extensionsToInstall = skipExtensionDependencies
+    ? extensions
+    : mergeDependentExtensions(extensions, extensionDevelopmentPaths);
 
   const [cli, ...cliArgs] = electron.resolveCliArgsFromVSCodeExecutablePath(vscodePath, {
     platform: desktopPlatform,


### PR DESCRIPTION
CC @connor4312 for review

Closes #5 

This is an implementation of installing prerequisite extensions. This draft does not tie into the reporter which seems to be specific to the test process and not prerequisite activities.

Follows the recommendations defined in https://github.com/microsoft/vscode-test README

Requesting feedback of the approach and how you want to handle reporting/status updates of the extension installation process, right now it just writes to `console.debug`

How to evalute
```powershell
vscode-cli --help
<read about the new -d and -e parameters>
vscode-cli -e 'ms-vscode.powershell' 'ms-vscode.js-debug-nightly@prerelease'
vscode-cli -d #Installs extensionDependencies from package.json
vscode-cli -d -e 'ms-vscode.powershell@prerelease' #Overrides what is in extensionDependencies version.
vscode-cli -e '/path/to/custom/extension.vsix'
```


For both the Pester and PowerShell vscode extensions, this functionality is mandatory for us to be able to adopt vscode-test-cli over our own runner.