### PR TITLE
fix: bailing multiple configs on first failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## TBA
+
+- Fix bailing multiple configs on first failure (fixes [#44](https://github.com/microsoft/vscode-test-cli/issues/44))
+
 ## 0.0.9 - 2024-03-04
 
 - Handle relative paths in `--config


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-test-cli/issues/44